### PR TITLE
Add project root directory in system path for sphinx docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,7 @@
 # serve to show the default.
 
 import sys, os
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.dirname(__file__))
 
 sys.path.append(os.path.abspath('_themes'))
 html_theme_path = ['_themes']


### PR DESCRIPTION
os.path.join(os.path.dirname(**file**), '..') and os.path.dirname(**file**)) are returning same path.
Hence removed the joining of path part.
