### PR TITLE
Fix json parser for Python 3 compatibility

### DIFF
--- a/retask/queue.py
+++ b/retask/queue.py
@@ -156,7 +156,7 @@ class Queue(object):
         data = self.rdb.brpop(self._name, wait_time)
         if data:
             task = Task()
-            task.__dict__ = json.loads(data[1])
+            task.__dict__ = json.loads(data[1].decode())
             return task
         else:
             return False
@@ -194,7 +194,7 @@ class Queue(object):
         if isinstance(data, six.binary_type):
             data = six.text_type(data, 'utf-8', errors = 'replace')
         task = Task()
-        task.__dict__ = json.loads(data)
+        task.__dict__ = json.loads(data.decode())
         return task
 
     def enqueue(self, task):
@@ -290,7 +290,7 @@ class Job(object):
         data = self.rdb.rpop(self.urn)
         if data:
             self.rdb.delete(self.urn)
-            data = json.loads(data)
+            data = json.loads(data.decode())
             self.__result = data
             return data
         else:
@@ -315,7 +315,7 @@ class Job(object):
         data = self.rdb.brpop(self.urn, wait_time)
         if data:
             self.rdb.delete(self.urn)
-            data = json.loads(data[1])
+            data = json.loads(data[1].decode())
             self.__result = data
             return True
         else:


### PR DESCRIPTION
I've been using Retask in python 3 and added this to address the JSON-unicode decode issue. Please consider merging this!
