### PR TITLE
Python 3 compatible find

### DIFF
--- a/retask/queue.py
+++ b/retask/queue.py
@@ -264,9 +264,13 @@ class Queue(object):
         if not self.connected:
             raise ConnectionError('Queue is not connected')
 
+        str_obj = str(obj)
         data = self.rdb.lrange(self._name, 0, -1)
         for i, datum in enumerate(data):
-            if datum.find(str(obj)) != -1:
+            if isinstance(datum, six.binary_type):
+                if str_obj in six.text_type(datum, 'utf-8', errors='replace'):
+                    return i
+            elif datum.find(str_obj) != -1:
                 return i
         return -1
 

--- a/retask/queue.py
+++ b/retask/queue.py
@@ -267,8 +267,8 @@ class Queue(object):
         str_obj = str(obj)
         data = self.rdb.lrange(self._name, 0, -1)
         for i, datum in enumerate(data):
-            if isinstance(datum, six.binary_type):
-                if str_obj in six.text_type(datum, 'utf-8', errors='replace'):
+            if isinstance(datum, bytes):
+                if str_obj in datum.decode("utf-8"):
                     return i
             elif datum.find(str_obj) != -1:
                 return i

--- a/tests.py
+++ b/tests.py
@@ -85,6 +85,27 @@ class GetQueueNamesTest(unittest.TestCase):
         rdb = redis.Redis()
         rdb.delete('retaskqueue-lambda')
 
+
+class FindObjQueueTest(unittest.TestCase):
+    """
+    Finds the index of the given object in the Queue
+
+    """
+    def setUp(self):
+        self.queue = Queue('findTest')
+        self.queue.connect()
+        t = Task({'name': 'mytask'})
+        self.queue.enqueue(t)
+
+    def runTest(self):
+        task_idx = self.queue.find('mytask')
+        self.assertEqual(task_idx, 0)
+
+    def tearDown(self):
+        rdb = redis.Redis()
+        rdb.delete('retaskqueue-findTest')
+
+
 if __name__ == '__main__':
     unittest.main()
 


### PR DESCRIPTION
Hello, 

`queue.find(obj)`

causes following TypeError when working with `redis==3.5.3`  and  `redis==4.5.1` packages:


```
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/.../python3.7/site-packages/retask/queue.py", line 266, in find
    if datum.find(str(obj)) != -1:
TypeError: argument should be integer or bytes-like object, not 'str'
```

Ubuntu 20.04 - python3.7
MacOS M1 Ventura - python3.9

Do you think it's worth considering?